### PR TITLE
Clarification of "the significant change" on link

### DIFF
--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2996,6 +2996,8 @@
             <li>The client returns from sleep mode.</li>
             <li>The client changes access points (e.g., if
               using Wi-Fi technology).</li>
+            <li>The client’s network interface indicates a disconnection event,
+            followed by a connection event.</li>
           </ul>
           <t>Specific algorithms for detecting network attachment changes are out of scope
           for this document. Two possible mechanisms for detecting situations where refreshing

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -3021,16 +3021,32 @@
           <t>If the client has only obtained network information using Information-request/Reply
           message exchanges, the client MUST initiate an Information-request/Reply message exchange as
           described in <xref target="RFC3315-18.1.5" format="default"/>.</t>
-          <t>If not associated with one of the above-mentioned conditions, a client SHOULD
-          initiate a Renew/Reply exchange (as if the T1 time expired) as described in
-          <xref target="RFC3315-18.1.3" format="default"/> or an Information-request/Reply exchange as
-          described in <xref target="RFC3315-18.1.5" format="default"/> if the client detects a
-          significant change regarding the prefixes available on the link. A change is considered significant
-          when one or more on-link prefixes are added, and/or one or more existing on-link prefixes are deprecated.
-          The reason for this is that such a significant change may indicate a configuration change at the server.
-          However, a client MUST rate‑limit such
-          attempts to avoid flooding a server with requests when there are link issues
-          (for example, only doing one of these at most every 30 seconds).</t>
+          <t>
+            If not associated with a detection of having moved to a new link, a
+            client SHOULD initiate one of the Renew/Reply, Confirm/Reply or
+            Information-request/Reply exchanges, if the client detects a
+            significant change regarding the prefixes available on the link.
+            A change is considered significant when one or more on-link
+            prefixes are added, and/or one or more existing on-link prefixes
+            are deprecated.
+            The reason for this is that such a significant change may indicate
+            a configuration change at the server.
+            However, a client MUST rate‑limit such exchange attempts to avoid
+            flooding a server with requests when there are link issues (for
+            example, only doing one of these at most every 30 seconds).
+          </t>
+          <t>
+            The above selection of an exchange to initiate depends on the client's current state:
+            <ul>
+              <li>If the client has any valid delegated prefixes obtained
+              from the server, it sends Renew (as if the T1 time expired) as
+              described in <xref target="RFC3315-18.1.3" />.
+              <li>Else, if the client obtained address(es) from the server,
+              it sends Confirm as described in <xref target="RFC3315-18.1.2" />.
+              <li>Else, if only network information was obtained from the
+              server, it sends Information-request as described in <xref section"RFC3315-18.1.5" />
+          </t>
+
         </section>
       </section>
       <section anchor="RFC3315-18.2" numbered="true" toc="default">

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -3037,15 +3037,16 @@
           </t>
           <t>
             The above selection of an exchange to initiate depends on the client's current state:
-            <ul>
-              <li>If the client has any valid delegated prefixes obtained
-              from the server, it sends Renew (as if the T1 time expired) as
-              described in <xref target="RFC3315-18.1.3" />.
-              <li>Else, if the client obtained address(es) from the server,
-              it sends Confirm as described in <xref target="RFC3315-18.1.2" />.
-              <li>Else, if only network information was obtained from the
-              server, it sends Information-request as described in <xref section"RFC3315-18.1.5" />
           </t>
+          <ul>
+            <li>If the client has any valid delegated prefixes obtained
+            from the server, it sends Renew (as if the T1 time expired) as
+            described in <xref target="RFC3315-18.1.3" />.</li>
+            <li>Else, if the client obtained address(es) from the server,
+            it sends Confirm as described in <xref target="RFC3315-18.1.2" />.</li>
+            <li>Else, if only network information was obtained from the
+            server, it sends Information-request as described in <xref target="RFC3315-18.1.5" /></li>
+          </ul>
 
         </section>
       </section>

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -3023,12 +3023,12 @@
           initiate a Renew/Reply exchange (as if the T1 time expired) as described in
           <xref target="RFC3315-18.1.3" format="default"/> or an Information-request/Reply exchange as
           described in <xref target="RFC3315-18.1.5" format="default"/> if the client detects a
-          significant change regarding the prefixes
-          available on the link (when new prefixes are added or existing prefixes
-          are deprecated), as this may indicate a configuration change.  However,
-          a client MUST rate‑limit such
+          significant change regarding the prefixes available on the link. A change is considered significant
+          when one or more on-link prefixes are added, and/or one or more existing on-link prefixes are deprecated.
+          The reason for this is that such a significant change may indicate a configuration change at the server.
+          However, a client MUST rate‑limit such
           attempts to avoid flooding a server with requests when there are link issues
-          (for example, only doing one of these at most every 30 seconds).</t>
+          (for example, only doing one of these at most every 30 seconds).</t>
         </section>
       </section>
       <section anchor="RFC3315-18.2" numbered="true" toc="default">

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2997,8 +2997,8 @@
             <li>The client changes access points (e.g., if
               using Wi-Fi technology).</li>
           </ul>
-          <t>Specific algorithms for detecting network attachement changes are out of scope
-          for this document. Two possible mechanisms for detecting situation where refreshing
+          <t>Specific algorithms for detecting network attachment changes are out of scope
+          for this document. Two possible mechanisms for detecting situations where refreshing
           configuration information may be needed, are defined in <xref target="RFC6059"
           format="default"/>, and <xref target="RFC4957" format="default" />.</t>
           <t>When the client detects that it may have moved to a new link and it


### PR DESCRIPTION
This PR is about resolving issues raised during WGLC by Esko Dijk. The [initial proposals](https://mailarchive.ietf.org/arch/msg/dhcwg/BtE7OBvoysnm0kySMYum9EUqEYc/) called for 5 changes:
1. rejected as it would change the normative language.
2. the requirement to send confirm,renew or inf-request needs to be clarified - discussion in progress
3. already applied on this PR
4. the M bit is informative.
5. I would be hesitant to add new normative language to add any extra delays.

I already applied changes proposed by Esko in his Nov. 11 mail regarding 3 (clarify the text significant changes).
