### PR TITLE
Avoid using enterprise-id 9 (assigned to Cisco)

### DIFF
--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -1457,7 +1457,7 @@ addresses, and this specification is now authoritative for:</t>
           ]]></artwork>
         </figure>
         <t>This example includes the 2-octet type of 2 and the Enterprise
-        Number (32473), followed by 8 octets of identifier data
+        Number (32473) (from <xref target="RFC5612"/>), followed by 8 octets of identifier data
         (0x0CC084D303000912).</t>
       </section>
       <section numbered="true" toc="default">

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -1450,14 +1450,14 @@ addresses, and this specification is now authoritative for:</t>
           <name>DUID-EN Example</name>
           <artwork align="left" name="" type="" alt=""><![CDATA[
    +---+---+---+---+---+---+---+---+
-   | 0 | 2 | 0 | 0 | 0 |  9| 12|192|
+   | 0 | 2 | 0 | 0 |126|217| 12|192|
    +---+---+---+---+---+---+---+---+
    |132|211| 3 | 0 | 9 | 18|
    +---+---+---+---+---+---+
           ]]></artwork>
         </figure>
         <t>This example includes the 2-octet type of 2 and the Enterprise
-        Number (9), followed by 8 octets of identifier data
+        Number (32473), followed by 8 octets of identifier data
         (0x0CC084D303000912).</t>
       </section>
       <section numbered="true" toc="default">


### PR DESCRIPTION
There was [an old thread on DHC](https://mailarchive.ietf.org/arch/msg/dhcwg/7D6nEiSY4ya2JO4u5e9lGKu4Fsw/), as reported by t petch that we should avoid using 9 and use 32473, an example enterprise-id as mandated by RFC5612.

And that's exactly what this PR does.