### PR TITLE
-09 editorials

### DIFF
--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -505,7 +505,7 @@
      addresses determined through other mechanisms for transmitting and
      receiving DHCP messages.</t>
       <t>A DHCP client sends messages using a reserved, link-scoped
-     multicast destination address (ALL_DHCP_Relay_Agenda_and_service - ff02::1:2) so that the client need not be
+     multicast destination address (ALL_DHCP_Relay_Agents_and_service - ff02::1:2) so that the client need not be
      configured with the address or addresses of DHCP servers.</t>
       <t>To allow a DHCP client to send a message to a DHCP server that is
      not attached to the same link, a DHCP relay agent on the client's link


### PR DESCRIPTION
When reviewing changes, I've spotted one typo:

 - ALL_DHCP_Relay_Agenda_and_service => ALL_DHCP_Relay_Agents_and_service

Let's keep this MR open for now in case more minor stuff needs fixing. Once we feel it's ready for merge (e.g. because we need to do -10 or for other reasons), we can turn draft PR into PR and merge.