### PR TITLE
Remaining Opsdir comments

### DIFF
--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2671,7 +2671,7 @@ addresses, and this specification is now authoritative for:</t>
           "transaction‑id" field.</t>
           <t>The client MUST include a Server Identifier option
           (see <xref target="RFC3315-22.3" format="default"/>) in the Renew
-          message, identifying the server with allocated the lease(s).</t>
+          message, identifying the server which allocated the lease(s).</t>
           <t>The client MUST include a Client Identifier option
           (see <xref target="RFC3315-22.2" format="default"/>) to identify
           itself to the server.</t>
@@ -2734,7 +2734,7 @@ addresses, and this specification is now authoritative for:</t>
 
           <t>The client MUST include a Server Identifier option
           (see <xref target="RFC3315-22.3" format="default"/>) in the Decline
-          message, identifying the server with allocated the lease(s).</t>
+          message, identifying the server which allocated the lease(s).</t>
           <t>The client MUST include a Client Identifier option
           (see <xref target="RFC3315-22.2" format="default"/>) to identify
           itself to the server.</t>
@@ -3019,7 +3019,7 @@ addresses, and this specification is now authoritative for:</t>
           using the configured NTP server address.  The client
           SHOULD be open to other sources of the same configuration
           information.  This behavior does not apply to any IA options,
-          as their processing is described in detail in the next section.</t>
+          as their processing is described in <xref target="reply-solicit-request-renew-rebind" /></t>
           </section>
         </section>
         <section numbered="true" toc="default">

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2850,27 +2850,8 @@ addresses, and this specification is now authoritative for:</t>
           for which the Reply was received.</t>
           <t>The client MAY choose to report any status code or message from
           the Status Code option in the Reply message.</t>
-          <t>When a client received a configuration option in an earlier
-          Reply and then sends a Renew, Rebind, or Information-request and
-          the requested option is not present in the Reply, the client
-          SHOULD stop using the previously received configuration
-          information.  In other words, the client should behave as if
-          it never received this configuration option and return to the
-          relevant default state.  If there is no viable way to stop using
-          the received configuration information, the values
-          received/configured from the option MAY persist if there are
-          no other sources for that data and they have no external impact.
-          For example, a client that previously received a Client FQDN
-          option (see <xref target="RFC4704" format="default"/>) and used it to set up
-          its hostname is allowed to continue
-          using it if there is no reasonable way for a node to unset its
-          hostname and it has no external impact.  As a counter-example,
-          a client that previously received an NTP server address from
-          the DHCP server and does not receive it anymore MUST stop
-          using the configured NTP server address.  The client
-          SHOULD be open to other sources of the same configuration
-          information.  This behavior does not apply to any IA options,
-          as their processing is described in detail in the next section.</t>
+          <t>The topic of revoking previously assigned options is discussed
+          in <xref target="revoking-config" format="default" />.</t>
           <t>When a client receives a requested option that has an updated
           value from what was previously received, the client SHOULD make
           use of that updated value as soon as possible for its configuration
@@ -3014,6 +2995,31 @@ addresses, and this specification is now authoritative for:</t>
             <t>Refer to <xref target="RFC4242-Option" format="default"/> for details on how the
             Information Refresh Time option (whether or not present in the
             Reply) should be handled by the client.</t>
+          </section>
+
+          <section anchor="revoking-config" numbered="true" toc="default">
+            <name>Revoking Previously Provided Options</name>
+          <t>When a client received a configuration option in an earlier
+          Reply and then sends a Renew, Rebind, or Information-request and
+          the requested option is not present in the Reply, the client
+          SHOULD stop using the previously received configuration
+          information.  In other words, the client should behave as if
+          it never received this configuration option and return to the
+          relevant default state.  If there is no viable way to stop using
+          the received configuration information, the values
+          received/configured from the option MAY persist if there are
+          no other sources for that data and they have no external impact.
+          For example, a client that previously received a Client FQDN
+          option (see <xref target="RFC4704" format="default"/>) and used
+          it to set up its hostname is allowed to continue
+          using it if there is no reasonable way for a node to unset its
+          hostname and it has no external impact.  As a counter-example,
+          a client that previously received an NTP server address from
+          the DHCP server and does not receive it anymore MUST stop
+          using the configured NTP server address.  The client
+          SHOULD be open to other sources of the same configuration
+          information.  This behavior does not apply to any IA options,
+          as their processing is described in detail in the next section.</t>
           </section>
         </section>
         <section numbered="true" toc="default">

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2014,7 +2014,7 @@ addresses, and this specification is now authoritative for:</t>
         <t>Servers and relay agents MUST discard any received Reply
         messages.</t>
       </section>
-      <section numbered="true" toc="default">
+      <section anchor="RFC3315-15.11" numbered="true" toc="default">
         <name>Reconfigure Message</name>
         <t>Servers and relay agents MUST discard any received Reconfigure
         messages.</t>
@@ -2645,10 +2645,9 @@ addresses, and this specification is now authoritative for:</t>
           client is interested in receiving. The client MAY include options
           with data values as hints to the server about parameter values the
           client would like to have returned.</t>
-          <t>When responding to a Reconfigure, the client includes a Server
+          <t>When responding to a Reconfigure, the client MUST include a Server
           Identifier option (see <xref target="RFC3315-22.3" format="default"/>) with the
-          identifier from the Reconfigure message
-          to which the client is responding.</t>
+          identifier from the Reconfigure message to which the client is responding.</t>
           <t>The first Information-request message from the client on the
           interface MUST be delayed by a random amount of time between 0 and
           INF_MAX_DELAY. The client transmits the message according to <xref target="RFC3315-14" format="default"/>, using the following parameters: </t>
@@ -2670,9 +2669,9 @@ addresses, and this specification is now authoritative for:</t>
           <t>The client sets the "msg-type" field to RELEASE. The client
           generates a transaction ID and places this value in the
           "transaction‑id" field.</t>
-          <t>The client places the identifier of the server that allocated the
-          lease(s) in a Server Identifier option
-           (see <xref target="RFC3315-22.3" format="default"/>).</t>
+          <t>The client MUST include a Server Identifier option
+          (see <xref target="RFC3315-22.3" format="default"/>) in the Renew
+          message, identifying the server with allocated the lease(s).</t>
           <t>The client MUST include a Client Identifier option
           (see <xref target="RFC3315-22.2" format="default"/>) to identify
           itself to the server.</t>
@@ -2732,9 +2731,10 @@ addresses, and this specification is now authoritative for:</t>
           <t>The client sets the "msg-type" field to DECLINE. The client
           generates a transaction ID and places this value in the
           "transaction‑id" field.</t>
-          <t>The client places the identifier of the server that allocated the
-          address(es) in a Server Identifier option
-          (see <xref target="RFC3315-22.3" format="default"/>).</t>
+
+          <t>The client MUST include a Server Identifier option
+          (see <xref target="RFC3315-22.3" format="default"/>) in the Decline
+          message, identifying the server with allocated the lease(s).</t>
           <t>The client MUST include a Client Identifier option
           (see <xref target="RFC3315-22.2" format="default"/>) to identify
           itself to the server.</t>
@@ -3030,6 +3030,9 @@ addresses, and this specification is now authoritative for:</t>
           programs, the client SHOULD log these events and MAY notify these
           programs of the change through an implementation-specific
           interface.</t>
+          <t>The message MUST be dropped if it doesn't pass the validation,
+          as explained in (see <xref target="RFC3315-15.11" format="default"/>),
+          in particular in case the authentication is missing or fails.</t>
           <t>Upon receipt of a valid Reconfigure message, the client responds
           with a Renew message, a Rebind message, or an
           Information-request message as indicated by the Reconfigure Message
@@ -3086,7 +3089,7 @@ addresses, and this specification is now authoritative for:</t>
           <t>When the client detects that it may have moved to a new link and it
           has obtained addresses and no delegated prefixes from a server, the
           client SHOULD initiate a Confirm/Reply message exchange. The client
-          includes any IAs assigned to the interface that may have moved to a
+          MUST include any IAs assigned to the interface that may have moved to a
           new link, along with the addresses associated with those IAs, in its
           Confirm message. Any responding servers will indicate whether those
           addresses are appropriate for the link to which the client is

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -2881,7 +2881,8 @@ addresses, and this specification is now authoritative for:</t>
             response to a Solicit (with a Rapid Commit option;
             see <xref target="RFC3315-22.14" format="default"/>) or a Request,
             the client can either reissue the message without specifying any
-            addresses or restart the DHCP server discovery process (see <xref target="configuration-exchange" format="default"/>).</t>
+            addresses or restart the DHCP server discovery process (see <xref target="configuration-exchange" format="default"/>
+            or <xref target="RFC8415bis-18.2.13" format="default"/>).</t>
             <t>If the Reply was received in response to a Solicit (with a
             Rapid Commit option), Request, Renew, or Rebind message, the
             client updates the information it has recorded about IAs from the
@@ -2986,12 +2987,6 @@ addresses, and this specification is now authoritative for:</t>
               <li>Otherwise accepts the information in the
                 IA.</li>
             </ul>
-            <t>Whenever a client restarts the DHCP server discovery process or
-            selects an alternate server as described in <xref target="RFC3315-17.1.3" format="default"/>, the client SHOULD stop using all
-            the addresses and delegated prefixes for which it has bindings and
-            try to obtain all required leases from the new server. This
-            facilitates the client using a single state machine for all
-            bindings.</t>
           </section>
           <section anchor="reply-release-decline" numbered="true" toc="default">
             <name>Reply for Release and Decline</name>

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -3132,6 +3132,17 @@ addresses, and this specification is now authoritative for:</t>
           </ul>
 
         </section>
+        <section anchor="RFC8415bis-18.2.13" numbered="true" toc="default">
+          <name>Restarting Server Discovery Process</name>
+          <t>Whenever a client restarts the DHCP server discovery process or
+        selects an alternate server as described in <xref target="RFC3315-17.1.3" />,
+        the client SHOULD stop using any addresses and delegated prefixes for
+        which it has bindings (see <xref target="RFC3315-18.1.6" />)
+        and any previously received other configuration
+        information, and try to obtain new bindings and other configuration
+        information from a "new" server. This facilitates the client using a
+        single state machine for all bindings.</t>
+        </section>
       </section>
       <section anchor="RFC3315-18.2" numbered="true" toc="default">
         <name>Server Behavior</name>

--- a/draft-ietf-dhc-rfc8415bis.xml
+++ b/draft-ietf-dhc-rfc8415bis.xml
@@ -3133,7 +3133,7 @@ addresses, and this specification is now authoritative for:</t>
         selects an alternate server as described in <xref target="RFC3315-17.1.3" />,
         the client SHOULD stop using any addresses and delegated prefixes for
         which it has bindings (see <xref target="RFC3315-18.1.6" />)
-        and any previously received other configuration
+        and if possible, any previously received other configuration
         information, and try to obtain new bindings and other configuration
         information from a "new" server. This facilitates the client using a
         single state machine for all bindings.</t>


### PR DESCRIPTION
Several comments raised by Tim were missed or we ran out of time before -10 was published. Here's the list:

- [x] 18.2.11 - Auth required
- [x] Normative language in 18.2.* and 18.3.*
- [x] what does a client do when restarting the discovery process - see #40 
- [x] what does the client do if subsequent transmission omits something - see #39

Fixes #40
Fixes #39 